### PR TITLE
Add support for React Native 0.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2019-06-01
 
+### Changed
+
+- Bump Kotlin to version `1.3.31`.
+
 ### Removed
 
 The following deprecated functions have been removed. Please see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump Kotlin to version `1.3.31`.
+- Remove explicit Android Build Tools version from Gradle configuration.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2019-07-13
+
+### Added
+
+- Compatibility with React Native `0.60.0` and, with it, [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md): no need to manually link anymore.
+
+### Removed
+
+- Compatibility with React Native versions below `0.60.0`. If you need to use an older version of React Native, check the [compatibility table](https://github.com/matei-radu/react-native-in-app-browser#compatibility) to use the appropriate package.
+
+### Changed
+
+- iOS podspec file has been updated to support React Native `0.60.0`.
+
 ## [2.0.0] - 2019-06-01
 
 ### Changed
@@ -142,6 +156,7 @@ The following functions have been deprecated. Please see
 
 - `openInApp`: open a valid http(s) URL with an in-app browser.
 
+[3.0.0]: https://github.com/matt-block/react-native-in-app-browser/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/matt-block/react-native-in-app-browser/compare/v1.4.1...v2.0.0
 [1.4.1]: https://github.com/matt-block/react-native-in-app-browser/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/matt-block/react-native-in-app-browser/compare/v1.3.0...v1.4.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ from the compatibility table below (if available):
 
 |  React Native   | Library |
 | :-------------: | :-----: |
-| 0.57.0 - 0.59.x | latest  |
+|     0.60.x      | latest  |
+| 0.57.0 - 0.59.x |  2.0.0  |
 
 ## Installation
 
@@ -33,7 +34,7 @@ yarn add @matt-block/react-native-in-app-browser
 npm install --save @matt-block/react-native-in-app-browser
 ```
 
-Proceed to link the native module to your project:
+**Only for React Native `0.59.x` and below**: link the native module to your project:
 
 ```
 react-native link @matt-block/react-native-in-app-browser

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "^16.5.0",
-    "react-native": "^0.57.0 || ^0.58.0 || ^0.59.0"
+    "react-native": "^0.57.0 || ^0.58.0 || ^0.59.0 || ^0.60.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "^16.5.0",
-    "react-native": "^0.57.0 || ^0.58.0 || ^0.59.0 || ^0.60.0"
+    "react-native": "^0.60.0"
   },
   "husky": {
     "hooks": {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -8,7 +8,6 @@
 buildscript {
     ext {
         kotlin_version = "1.3.31"
-        buildToolsVersion = "28.0.2"
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27
@@ -40,7 +39,6 @@ apply plugin: 'maven'
 
 android {
     compileSdkVersion getRootProjectOrDefaultValueFor("compileSdkVersion")
-    buildToolsVersion getRootProjectOrDefaultValueFor("buildToolsVersion")
 
     defaultConfig {
         minSdkVersion getRootProjectOrDefaultValueFor("minSdkVersion")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -7,7 +7,7 @@
 
 buildscript {
     ext {
-        kotlin_version = "1.3.21"
+        kotlin_version = "1.3.31"
         buildToolsVersion = "28.0.2"
         minSdkVersion = 16
         compileSdkVersion = 28

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -12,7 +12,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
-import android.support.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule

--- a/src/ios/react-native-in-app-browser.podspec
+++ b/src/ios/react-native-in-app-browser.podspec
@@ -10,9 +10,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.author = package['author']
   s.homepage = package['homepage']
-  s.source = { :git => 'https://github.com/matt-block/react-native-in-app-browser' }
+  s.source = { :git => 'https://github.com/matei-radu/react-native-in-app-browser' }
   s.platform = :ios, '9.0'
   s.dependency 'React'
-  s.source_files = '*.{h,m,swift}'
+  s.swift_versions = ['4.2', '5']
+  s.source_files = '**/*.{h,m,swift}'
   s.preserve_paths = '*.js'
 end


### PR DESCRIPTION
This PR adds the necessary changes to add support for React Native `v0.60`.

Version `0.60` brings some pretty big changes to the project structure, mainly:

- Add AndroidX support
- CocoaPods dependency management for iOS by default

Both these changes force this module to make some breaking changes, making it incompatible with previous versions of RN.

Closes #63.