### PR TITLE
Add Android-only warmup and mayLaunchUrl methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Android specific `warmup` and `mayLaunchUrl` methods to reduce custom tab activity start time.
+
 ## [3.0.0] - 2019-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ async onClickHandler() {
 }
 ```
 
+### Startup optimizations (Android only)
+
+Chrome Custom Tabs exposes methods to reduce the start time of a custom tab activity.
+
+For information on how these work, check [Custom Tabs - Example and Usage Optimization](https://chromium.googlesource.com/external/github.com/GoogleChrome/custom-tabs-client/+/08e2c9155aff7296428aae854769c30b4060ae88/README.md#optimization)
+
+```javascript
+import { InAppBrowser } from "@matt-block/react-native-in-app-browser";
+
+InAppBrowser.warmup();
+InAppBrowser.mayLaunchUrl("https://wikipedia.org");
+```
+
 ### Programmatically close (iOS only)
 
 It is possible to manually dismiss the iOS in-app instance by calling the method `close`.

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -97,6 +97,15 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
     }
 
     @ReactMethod
+    fun warmup(promise: Promise) {
+        try {
+            promise.resolve(mClient!!.warmup(0))
+        } catch (e: NullPointerException) {
+            promise.reject(e)
+        }
+    }
+
+    @ReactMethod
     fun mayLaunchUrl(url: String, promise: Promise) =
             promise.resolve(mSession?.mayLaunchUrl(Uri.parse(url), null, null) ?: false)
 

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -13,6 +13,7 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsClient
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -29,6 +30,19 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
         private const val SETTING_SHOW_TITLE = "showTitle"
         private const val SETTING_CLOSE_BUTTON = "closeButtonIcon"
         private const val SETTING_SHARE_MENU = "addDefaultShareMenu"
+
+        private val CUSTOMTABS_BROWSERS = listOf(
+                "com.android.chrome",           // Google Chrome - Stable
+                "com.chrome.beta",              // Google Chrome - Beta
+                "com.chrome.dev",               // Google Chrome - Dev
+                "com.chrome.canary",            // Google Chrome - Canary
+
+                "org.mozilla.firefox",          // Mozilla Firefox - Stable
+                "org.mozilla.firefox_beta",     // Mozilla Firefox - Beta
+                "org.mozilla.fennec_aurora",    // Mozilla Firefox - Nightly
+
+                "com.sec.android.app.sbrowser"  // Samsung Internet
+        )
     }
 
     override fun getName() = "RNInAppBrowser"
@@ -91,11 +105,14 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
     private fun getBitmapFromDrawable(drawableName: String): Bitmap? {
         return this.currentActivity?.let { activity ->
             BitmapFactory.decodeResource(
-                activity.resources,
-                activity.resources?.getIdentifier(drawableName, "drawable", activity.packageName)!!
+                    activity.resources,
+                    activity.resources?.getIdentifier(drawableName, "drawable", activity.packageName)!!
             )
         }
     }
+
+    private fun getPreferredBrowserPackageName() =
+            CustomTabsClient.getPackageName(this.reactApplicationContext, CUSTOMTABS_BROWSERS)
 
     /**
      * Since this is a separate module, [BuildConfig.DEBUG] is not reliable.

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -7,13 +7,15 @@
 
 package com.mattblock.reactnative.inappbrowser
 
+import android.content.ComponentName
 import android.content.pm.ApplicationInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsServiceConnection
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -43,6 +45,21 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
 
                 "com.sec.android.app.sbrowser"  // Samsung Internet
         )
+    }
+
+    private var mClient: CustomTabsClient? = null
+
+    init {
+        val packageName = getPreferredBrowserPackageName()
+        CustomTabsClient.bindCustomTabsService(context, packageName, object : CustomTabsServiceConnection() {
+            override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
+                mClient = client
+            }
+
+            override fun onServiceDisconnected(name: ComponentName) {
+                mClient = null
+            }
+        })
     }
 
     override fun getName() = "RNInAppBrowser"

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -13,6 +13,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
+import android.os.Bundle
 import androidx.browser.customtabs.*
 
 import com.facebook.react.bridge.*
@@ -106,8 +107,10 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
     }
 
     @ReactMethod
-    fun mayLaunchUrl(url: String, promise: Promise) =
-            promise.resolve(mSession?.mayLaunchUrl(Uri.parse(url), null, null) ?: false)
+    fun mayLaunchUrl(url: String, otherLikelyUrls: ReadableArray, promise: Promise) {
+        val additionalUris = createOtherLikelyUrlBundles(otherLikelyUrls)
+        promise.resolve(mSession?.mayLaunchUrl(Uri.parse(url), null, additionalUris) ?: false)
+    }
 
     private fun getBitmapFromUriOrDrawable(uriOrDrawable: String): Bitmap? {
         return if (isDebug()) {
@@ -141,6 +144,18 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
 
     private fun getPreferredBrowserPackageName() =
             CustomTabsClient.getPackageName(this.reactApplicationContext, CUSTOMTABS_BROWSERS)
+
+    private fun createOtherLikelyUrlBundles(otherLikelyUrls: ReadableArray): List<Bundle>? {
+        if (otherLikelyUrls.size() == 0) {
+            return null
+        }
+
+        return List(otherLikelyUrls.size()) {
+            val bundle = Bundle()
+            bundle.putString("url", otherLikelyUrls.getString(it))
+            bundle
+        }
+    }
 
     /**
      * Since this is a separate module, [BuildConfig.DEBUG] is not reliable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,27 @@ class InAppBrowser {
   }
 
   /**
+   * Warm up the browser process.
+   *
+   * Allows the browser application to pre-initialize itself in the background.
+   * Significantly speeds up URL opening in the browser. This is asynchronous
+   * and can be called several times.
+   *
+   * This feature is Android only.
+   */
+  static async warmup(): Promise<boolean> {
+    if (Platform.OS === "android") {
+      try {
+        return NativeModules.RNInAppBrowser.warmup();
+      } catch (e) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Tell the browser of a likely future navigation to a URL.
    *
    * All previous calls to this method will be deprioritized.

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,21 @@ class InAppBrowser {
   }
 
   /**
+   * Tell the browser of a likely future navigation to a URL.
+   *
+   * All previous calls to this method will be deprioritized.
+   *
+   * This feature is Android only.
+   */
+  static async mayLaunchUrl(url: string): Promise<boolean> {
+    if (Platform.OS === "android") {
+      return NativeModules.RNInAppBrowser.mayLaunchUrl(url);
+    }
+
+    return false;
+  }
+
+  /**
    * Configure the platform-specific settings for the in-app browser
    * experience.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,13 +68,24 @@ class InAppBrowser {
   /**
    * Tell the browser of a likely future navigation to a URL.
    *
-   * All previous calls to this method will be deprioritized.
+   * The method `warmup()` has to be called beforehand.
+   *
+   * Optionally, a list of other likely URLs can be provided. They are treated
+   * as less likely than the first one, and have to be sorted in decreasing
+   * priority order. These additional URLs may be ignored.All previous calls to
+   * this method will be deprioritized.
    *
    * This feature is Android only.
    */
-  static async mayLaunchUrl(url: string): Promise<boolean> {
+  static async mayLaunchUrl(
+    url: string,
+    additionalUrls?: string[]
+  ): Promise<boolean> {
     if (Platform.OS === "android") {
-      return NativeModules.RNInAppBrowser.mayLaunchUrl(url);
+      return NativeModules.RNInAppBrowser.mayLaunchUrl(
+        url,
+        additionalUrls ? additionalUrls : []
+      );
     }
 
     return false;


### PR DESCRIPTION
As requested in #69, this PR adds the Android-specific methods:

- `async warmup(): Promise<boolean>`
- `async mayLaunchUrls(url: string, additionalUrls?: string[]): Promise<boolean>`.

Both methods are part of the `InAppBrowser` object and will resolve to `true` if they succeed in their intent, `false` otherwise.