### PR TITLE
Fix CustomTabs binding when no compatible browser is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- On Android, crash on app launch when there are no Custom Tabs compatible browsers available.
+
 ## [2.1.1] - 2019-08-08
 
 ### Fixed

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -48,17 +48,23 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
 
     init {
         val packageName = getPreferredBrowserPackageName()
-        CustomTabsClient.bindCustomTabsService(context, packageName, object : CustomTabsServiceConnection() {
-            override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
-                mClient = client
-                mSession = client.newSession(CustomTabsCallback())
-            }
 
-            override fun onServiceDisconnected(name: ComponentName) {
-                mClient = null
-                mSession = null
-            }
-        })
+        // The device could have no Custom Tabs compatible browser, in which case `packageName`
+        // will be null.
+        // See https://github.com/matei-radu/react-native-in-app-browser/issues/75
+        packageName?.let { it ->
+            CustomTabsClient.bindCustomTabsService(context, it, object : CustomTabsServiceConnection() {
+                override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
+                    mClient = client
+                    mSession = client.newSession(CustomTabsCallback())
+                }
+    
+                override fun onServiceDisconnected(name: ComponentName) {
+                    mClient = null
+                    mSession = null
+                }
+            })
+        }
     }
 
     override fun getName() = "RNInAppBrowser"
@@ -102,7 +108,7 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
         try {
             promise.resolve(mClient!!.warmup(0))
         } catch (e: NullPointerException) {
-            promise.reject(e)
+            promise.resolve(e)
         }
     }
 


### PR DESCRIPTION
The `CustomTabsClient` can bind only to a specific browser that is compatible with CustomTabs. However, if there are no compatible browsers the `CustomTabsClient` will attempt to bind to a null browser.

This commits binds the service only when a valid `packageName` is returned from `getPreferredBrowserPackageName()`.

Closes #75 