### PR TITLE
Bump Node.js version to LTS v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit:
     docker:
-      - image: circleci/node:8.12.0
+      - image: circleci/node:12.13.0
 
     working_directory: ~/unit
 
@@ -43,7 +43,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/node:8.12.0
+      - image: circleci/node:12.13.0
 
     working_directory: ~/deploy
     steps:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/erbium


### PR DESCRIPTION
Since LTS v8 will soon reach EOL, this commit bumps the NVM and CircleCI configurations to use the most recent LTS v12.