### PR TITLE
Add TypeScript and Android validation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ types/
 package/
 *.tgz
 coverage/
+.gradle/
 
 ## Example project exceptions
 !example/android

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "create-release": "ts-node -O '{\"types\":[\"node\"]}' scripts/createRelease.ts",
     "prepare-release-merge": "ts-node -O '{\"types\":[\"node\"]}' scripts/prepareRelease.ts",
     "ci-publish": "ts-node -O '{\"types\":[\"node\"]}' scripts/publishCI.ts",
+    "validate:android": "cd src/android && ./gradlew spotlessCheck",
+    "validate:android:fix": "cd src/android && ./gradlew spotlessApply",
     "validate:eslint": "eslint \"src/**/*.{js,ts,tsx}\" \"example/**/*.{js,ts,tsx}\"",
     "validate:typescript": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "create-release": "ts-node -O '{\"types\":[\"node\"]}' scripts/createRelease.ts",
     "prepare-release-merge": "ts-node -O '{\"types\":[\"node\"]}' scripts/prepareRelease.ts",
     "ci-publish": "ts-node -O '{\"types\":[\"node\"]}' scripts/publishCI.ts",
-    "validate:eslint": "eslint \"src/**/*.{js,ts,tsx}\" \"example/**/*.{js,ts,tsx}\""
+    "validate:eslint": "eslint \"src/**/*.{js,ts,tsx}\" \"example/**/*.{js,ts,tsx}\"",
+    "validate:typescript": "tsc --noEmit"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^0.0.5",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -30,12 +30,22 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.25.0"
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven'
+apply plugin: 'com.diffplug.gradle.spotless'
+
+spotless {
+  kotlin {
+    target '**/*.kt'
+
+    ktlint()
+  }
+}
 
 android {
     compileSdkVersion getRootProjectOrDefaultValueFor("compileSdkVersion")

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserModule.kt
@@ -14,11 +14,18 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
-import androidx.browser.customtabs.*
-
-import com.facebook.react.bridge.*
+import androidx.browser.customtabs.CustomTabsCallback
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsServiceConnection
+import androidx.browser.customtabs.CustomTabsSession
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
-
 import java.io.IOException
 import java.net.URL
 
@@ -30,16 +37,16 @@ class RNInAppBrowserModule(context: ReactApplicationContext) : ReactContextBaseJ
         private const val SETTING_SHARE_MENU = "addDefaultShareMenu"
 
         private val CUSTOMTABS_BROWSERS = listOf(
-                "com.android.chrome",           // Google Chrome - Stable
-                "com.chrome.beta",              // Google Chrome - Beta
-                "com.chrome.dev",               // Google Chrome - Dev
-                "com.chrome.canary",            // Google Chrome - Canary
+                "com.android.chrome", // Google Chrome - Stable
+                "com.chrome.beta", // Google Chrome - Beta
+                "com.chrome.dev", // Google Chrome - Dev
+                "com.chrome.canary", // Google Chrome - Canary
 
-                "org.mozilla.firefox",          // Mozilla Firefox - Stable
-                "org.mozilla.firefox_beta",     // Mozilla Firefox - Beta
-                "org.mozilla.fennec_aurora",    // Mozilla Firefox - Nightly
+                "org.mozilla.firefox", // Mozilla Firefox - Stable
+                "org.mozilla.firefox_beta", // Mozilla Firefox - Beta
+                "org.mozilla.fennec_aurora", // Mozilla Firefox - Nightly
 
-                "com.sec.android.app.sbrowser"  // Samsung Internet
+                "com.sec.android.app.sbrowser" // Samsung Internet
         )
     }
 

--- a/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserPackage.kt
+++ b/src/android/src/main/kotlin/com/mattblock/reactnative/inappbrowser/RNInAppBrowserPackage.kt
@@ -8,7 +8,6 @@
 package com.mattblock.reactnative.inappbrowser
 
 import com.facebook.react.ReactPackage
-import com.facebook.react.bridge.JavaScriptModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 


### PR DESCRIPTION
As part of #57, this PR adds additional validation scripts to:

- Check TypeScript typings, `validate:typescript`
- Lint and fix Android Kotlin files, `validate:android` and `valida:android:fix`