### PR TITLE
Replace tinycolor2 with @ctrl/tinycolor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `tinycolor2` was replaced with the fork `@ctrl/tinycolor` because the the former has not received an update since 2016.
+
 ## [3.1.3] - 2019-12-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ ignored and their default values will be used.
 
 | Setting               | Type                                                | Default     | Description                                                                                                                |
 | --------------------- | --------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `toolbarColor`        | `string`                                            | `undefined` | The color to tint the background of the toolbar.<br/>Provided color can be in any [TinyColor][tinycolor] supported format. |
+| `toolbarColor`        | `string`                                            | `undefined` | The color to tint the background of the toolbar.<br/>Provided color can be in any [@ctrl/tinycolor][tinycolor] supported format. |
 | `showTitle`           | `boolean`                                           | `false`     | Flag to toggle if the page title should be shown in the custom tab.                                                        |
 | `closeButtonIcon`     | `string` _(as resolved by importing an image file)_ | `undefined` | Custom close button icon.<br/><br/>Provided icon must be a `.png`, `.jpg`, or `.gif` file.                                 |
 | `addDefaultShareMenu` | `boolean`                                           | `false`     | Flag to toggle the default share menu.                                                                                     |
@@ -199,8 +199,8 @@ supported by the iOS version at runtime will be ignored as well.
 
 | Setting                     | Type      | Default     | Description                                                                                                                                                                                    |
 | --------------------------- | --------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `preferredBarTintColor`     | `string`  | `undefined` | The color to tint the background of the navigation bar and the toolbar.<br/>Provided color can be in any [TinyColor][tinycolor] supported format.<br/><br/>**Available on**: iOS >= 10.0.      |
-| `preferredControlTintColor` | `string`  | `undefined` | The color to tint the control buttons on the navigation bar and the toolbar.<br/>Provided color can be in any [TinyColor][tinycolor] supported format.<br/><br/>**Available on**: iOS >= 10.0. |
+| `preferredBarTintColor`     | `string`  | `undefined` | The color to tint the background of the navigation bar and the toolbar.<br/>Provided color can be in any [@ctrl/tinycolor][tinycolor] supported format.<br/><br/>**Available on**: iOS >= 10.0.      |
+| `preferredControlTintColor` | `string`  | `undefined` | The color to tint the control buttons on the navigation bar and the toolbar.<br/>Provided color can be in any [@ctrl/tinycolor][tinycolor] supported format.<br/><br/>**Available on**: iOS >= 10.0. |
 | `barCollapsingEnabled`      | `boolean` | `true`      | **Available on**: iOS >= 11.0.                                                                                                                                                                 |
 
 ## Example
@@ -241,4 +241,4 @@ This source code is licensed under the MIT license found in the
 [npm_1_shield]: https://img.shields.io/badge/npm-v1.4.1-blue
 [circleci]: https://circleci.com/gh/matei-radu/react-native-in-app-browser/tree/master
 [circleci_shield]: https://circleci.com/gh/matei-radu/react-native-in-app-browser/tree/master.svg?style=shield
-[tinycolor]: https://github.com/bgrins/TinyColor
+[tinycolor]: https://github.com/TypeCtrl/tinycolor

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/react-native": "^0.60.25",
     "@types/semver": "^6.2.0",
     "@types/shelljs": "^0.8.6",
-    "@types/tinycolor2": "^1.4.1",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "commander": "^4.0.1",
@@ -88,6 +87,6 @@
     ]
   },
   "dependencies": {
-    "tinycolor2": "^1.4.1"
+    "@ctrl/tinycolor": "^2.5.4"
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@
  */
 
 import { PlatformOSType, Image } from 'react-native';
-import tinycolor, { ColorInputWithoutInstance } from 'tinycolor2';
+import { TinyColor, ColorInput } from '@ctrl/tinycolor';
 
 export interface Settings {
   /**
@@ -34,7 +34,7 @@ export interface SettingsAndroid {
    *
    * **Note**: if the color string is invalid, this setting will be ignored.
    */
-  toolbarColor?: ColorInputWithoutInstance;
+  toolbarColor?: ColorInput;
 
   /**
    * Flag to toggle if the title should be shown in the custom tab.
@@ -70,7 +70,7 @@ export interface SettingsIOS {
    * **Note**: if the color string is invalid or if the current iOS version
    * is < 10.0, this setting will be ignored.
    */
-  preferredBarTintColor?: ColorInputWithoutInstance;
+  preferredBarTintColor?: ColorInput;
 
   /**
    * The color to tint the control buttons on the navigation bar and the
@@ -81,7 +81,7 @@ export interface SettingsIOS {
    * **Note**: if the color string is invalid or if the current iOS version
    * is < 10.0, this setting will be ignored.
    */
-  preferredControlTintColor?: ColorInputWithoutInstance;
+  preferredControlTintColor?: ColorInput;
 
   /**
    * **Available on**: iOS >= 11.0.
@@ -112,8 +112,9 @@ function sanitizeAndroid(settings?: SettingsAndroid): SettingsAndroid {
     return sanitized;
   }
 
-  if (tinycolor(settings.toolbarColor).isValid()) {
-    sanitized.toolbarColor = tinycolor(settings.toolbarColor).toHexString();
+  const toolbarColor = new TinyColor(settings.toolbarColor);
+  if (toolbarColor.isValid) {
+    sanitized.toolbarColor = toolbarColor.toHexString();
   }
 
   if (typeof settings.showTitle === 'boolean') {
@@ -142,8 +143,9 @@ function sanitizeIOS(settings?: SettingsIOS): SettingsIOS {
 
   const colors = ['preferredBarTintColor', 'preferredControlTintColor'];
   colors.forEach(color => {
-    if (tinycolor(settings[color]).isValid()) {
-      sanitized[color] = tinycolor(settings[color]).toHexString();
+    const parsedColor = new TinyColor(settings[color]);
+    if (parsedColor.isValid) {
+      sanitized[color] = parsedColor.toHexString();
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ctrl/tinycolor@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-2.5.4.tgz#fa20f45eaae74696070328342553ed5de224bb4d"
+  integrity sha512-PXqAcLD6R8GL8dFcls728HrYzDdYN60U8RXvc39wmOs1pJIcyc3g+dleWu+fGgLnEGG4SwblEUu+EF4/dH/2ew==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1122,11 +1127,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/tinycolor2@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.1.tgz#2f5670c9d1d6e558897a810ed284b44918fc1253"
-  integrity sha512-25L/RL5tqZkquKXVHM1fM2bd23qjfbcPpAZ2N/H05Y45g3UEi+Hw8CbDV28shKY8gH1SHiLpZSxPI1lacqdpGg==
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -6011,9 +6011,9 @@ regjsgen@^0.5.0:
   integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
 
 regjsparser@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
-  integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.1.tgz#5b6b28c418f312ef42898dc6865ae2d4b9f0f7a2"
+  integrity sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==
   dependencies:
     jsesc "~0.5.0"
 
@@ -6818,11 +6818,6 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
-
-tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
`tinycolor2` has not received an update since 2016 and it can be considered unmaintained at this point.

`@ctrl/tinycolor` is a fork of the former that is actively maintained and written in TypeScript.